### PR TITLE
[Release] Update version to 8.4.3

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -18,4 +18,4 @@
 package cmd
 
 // name matches github.com/elastic/beats/v7/dev-tools/mage/settings.go parseBeatVersion
-const defaultBeatVersion = "8.4.2"
+const defaultBeatVersion = "8.4.3"


### PR DESCRIPTION
Updates references to the new release 8.4.3.

Merge after the release 8.4.2.